### PR TITLE
Implement Course DTO and service for published course listing

### DIFF
--- a/lms-backend/src/main/java/com/example/lms/api/CourseController.java
+++ b/lms-backend/src/main/java/com/example/lms/api/CourseController.java
@@ -1,7 +1,7 @@
 package com.example.lms.api;
 
-import com.example.lms.course.Course;
-import com.example.lms.course.CourseRepository;
+import com.example.lms.course.CourseService;
+import com.example.lms.course.dto.CourseDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,15 +12,15 @@ import java.util.List;
 @RequestMapping("/api")
 public class CourseController {
 
-    private final CourseRepository courseRepository;
+    private final CourseService courseService;
 
-    public CourseController(CourseRepository courseRepository) {
-        this.courseRepository = courseRepository;
+    public CourseController(CourseService courseService) {
+        this.courseService = courseService;
     }
 
     // Публичный список опубликованных курсов
     @GetMapping("/courses")
-    public List<Course> listPublished() {
-        return courseRepository.findAllByPublishedTrueOrderByCreatedAtDesc();
+    public List<CourseDto> listPublished() {
+        return courseService.getPublished();
     }
 }

--- a/lms-backend/src/main/java/com/example/lms/course/CourseService.java
+++ b/lms-backend/src/main/java/com/example/lms/course/CourseService.java
@@ -1,0 +1,32 @@
+package com.example.lms.course;
+
+import com.example.lms.course.dto.CourseDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CourseService {
+
+    private final CourseRepository courses;
+
+    public CourseService(CourseRepository courses) {
+        this.courses = courses;
+    }
+
+    public List<CourseDto> getPublished() {
+        return courses.findAllByPublishedTrueOrderByCreatedAtDesc()
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private CourseDto toDto(Course course) {
+        CourseDto dto = new CourseDto();
+        dto.setId(course.getId());
+        dto.setTitle(course.getTitle());
+        dto.setDescription(course.getDescription());
+        return dto;
+    }
+}

--- a/lms-backend/src/main/java/com/example/lms/course/dto/CourseDto.java
+++ b/lms-backend/src/main/java/com/example/lms/course/dto/CourseDto.java
@@ -1,0 +1,40 @@
+package com.example.lms.course.dto;
+
+public class CourseDto {
+    private Long id;
+    private String title;
+    private String description;
+
+    public CourseDto() {
+    }
+
+    public CourseDto(Long id, String title, String description) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}


### PR DESCRIPTION
## Summary
- add `CourseDto` with id, title and description fields
- introduce `CourseService` to map published courses to DTOs
- update `CourseController` to return `List<CourseDto>` via service

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a45b9a81f483239d6fc61edabc62c4